### PR TITLE
fix: shulker boxes treated as beacon shulker

### DIFF
--- a/data/zerotask/functions/beacon_shulker/private/shulker_box/properties/is_beacon_box.mcfunction
+++ b/data/zerotask/functions/beacon_shulker/private/shulker_box/properties/is_beacon_box.mcfunction
@@ -6,4 +6,4 @@
 #######################################################################
 
 scoreboard players set #is_beacon_shulker_box zt.bs.var 0
-execute if data block ~ ~ ~ Items[{Slot: 13b}] run scoreboard players set #is_beacon_shulker_box zt.bs.var 1
+execute if data block ~ ~ ~ Items[{Slot: 13b, id: "minecraft:beacon"}].tag.Blocks run scoreboard players set #is_beacon_shulker_box zt.bs.var 1


### PR DESCRIPTION
The beacon shulker check didn't account for the needed Block NBT tag
that the item in slot 13 had to have to be a valid beacon shulker. Thus,
if a shulker box with an item in slot 13 (the middle one) got placed, it
was treated as if it was a beacon shulker. A beacon would have been
placed and the datapack tried to create the beacon layers. Since the
data for those layers wasn't present, the datapack would simply drop an
empty shulker box, thus deleting all items inside it.

Fixes #2